### PR TITLE
decouple begin/end within update, exposes swap function

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -222,8 +222,16 @@ var Stats = function () {
 
 		domElement: _container,
 
-		update: function () {
+    begin: function(time) {
+			_time = time || new Date().getTime();
+			_timeLastFrame = _time;
+			if ( _time > _timeLastSecond + 1000 ) {
+			  _timeLastSecond = _time;
+				_frames = 0;
+      }
+    },
 
+    end: function() {
 			_frames ++;
 
 			_time = new Date().getTime();
@@ -236,8 +244,6 @@ var Stats = function () {
 
 			_msText.innerHTML = '<span style="font-weight:bold">' + _ms + ' MS</span> (' + _msMin + '-' + _msMax + ')';
 			_msContext.putImageData( _msImageData, 0, 0 );
-
-			_timeLastFrame = _time;
 
 			if ( _time > _timeLastSecond + 1000 ) {
 
@@ -262,14 +268,18 @@ var Stats = function () {
 					_mbContext.putImageData( _mbImageData, 0, 0 );
 
 				}
-
-				_timeLastSecond = _time;
-				_frames = 0;
-
 			}
+      return _time;
+    },
 
-		}
+		update: function () {
+      var time = this.end();
+      this.begin(time);
+		},
 
+    swap: function() {
+      swapMode();
+    }
 	};
 
 };


### PR DESCRIPTION
I've tried to add support on stats.js for an environment where there's no "requestAnimationFrame()" type of draw loop.

My case is specifically a board game that only gets updated when there's a change or an animation. On this case, draw() may get into a requestAnimationFrame for a while or may be called from an event. In those cases, having a single update() entry point that measures everything outside of it is useless.

I've decoupled update into a "get start time" (begin) and "do the rest" (end) so they can be called separately.

The normal use case (still completely supported with update() ):

```
  ...measured code...
  stats.update();
  ...measured code...
```

my new use case.

```
  ...stuff happening...
  stats.begin();
  ...measured code...
  stats.end();
  ...more stuff happening...
```

I've also added a swap() function to swap modes, since there was no way to make the JS code to change it.
Hope you like the change. Let me know.

[]s
F.
