### PR TITLE
Access FPS being achieved

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -171,6 +171,12 @@ var Stats = function () {
 
 			startTime = this.end();
 
+		},
+
+		fps: function () {
+
+			return fps;
+
 		}
 
 	};


### PR DESCRIPTION
It seems I couldn't access the FPS being achieved without adding a function? Maybe there's a better way. It seems useful to be able to access this from the Stats. I'll need to do something separately to track it otherwise.