### PR TITLE
Update main to uncompiled script.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "stats.js",
 	"homepage": "https://github.com/mrdoob/stats.js",
 	"description": "JavaScript Performance Monitor",
-	"main": "build/stats.min.js",
+	"main": "src/Stats.js",
 	"keywords": [
 		"stats",
 		"statistics",


### PR DESCRIPTION
Updates `main` to the uncompiled version for a few reasons:
 - **bower does not allow minified main files, so installing sometimes yields an error**
 - it should be in the user's hands to minify their scripts
 - users can ultimately still access the minified version, so nothing it lost