### PR TITLE
Don't ignore src directory

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
 	"license": "MIT",
 	"ignore": [
 		"examples",
-		"src",
 		"utils",
 		"LICENSE"
 	]


### PR DESCRIPTION
The prior PR changed the main to `src/Stats.js` but didn't remove the `src` directory from the ignore array. This should make package work on bower again.