### PR TITLE
Exclude unrelated files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "directories": {
     "example": "examples"
   },
+  "files": [
+    "build",
+    "src"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I noticed that npm package for stats.js includes Google's Closure Compiler jar, which amounts to > 6 MB of wasted space per installation.

After this patch, only the following files are included:

```
build/stats.min.js
LICENSE
package.json
README.md
src/Stats.js
```