### PR TITLE
add options for container and cssText

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -2,12 +2,22 @@
  * @author mrdoob / http://mrdoob.com/
  */
 
-var Stats = function () {
+/**
+ * @param {Object} [opts]
+ * @param {Object} [opts.container] - container DOM node
+ * @param {Object} [opts.cssText] - This style string will be applied to the conatiner. Use a falsey value (except `undefined`) to skip set.
+ */
+var Stats = function (opts) {
+	opts = opts || {};
+	opts.container = opts.container || document.createElement( 'div' );
+	opts.cssText = opts.cssText !== undefined ? opts.cssText : 'position:fixed;top:0;left:0;cursor:pointer;opacity:0.9;z-index:10000';
 
 	var mode = 0;
 
-	var container = document.createElement( 'div' );
-	container.style.cssText = 'position:fixed;top:0;left:0;cursor:pointer;opacity:0.9;z-index:10000';
+	var container = opts.container;
+	if (opts.cssText) {
+		container.style.cssText = opts.cssText;
+	}
 	container.addEventListener( 'click', function ( event ) {
 
 		event.preventDefault();


### PR DESCRIPTION
I am using stats.js in a react project.  This means I do not want stats creating dom nodes.  This PR lets a user configure the stats style string, as well as the container element.

React example usage:

``` js
CoolComponent extends React.Component {
  componentDidMount () {
    this._stats = new Stats({ container: this.refs.statsContainer, cssText: '' });
  }

  render () {
    return (
      <div class='cool-component'>
        <div ref='statsContainer' />
      </div>
    );
  }
}
```