### PR TITLE
Remove "self" from call to performance

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -43,7 +43,7 @@ var Stats = function () {
 	var fpsPanel = addPanel( new Stats.Panel( 'FPS', '#0ff', '#002' ) );
 	var msPanel = addPanel( new Stats.Panel( 'MS', '#0f0', '#020' ) );
 
-	if ( self.performance && self.performance.memory ) {
+	if ( performance && performance.memory ) {
 
 		var memPanel = addPanel( new Stats.Panel( 'MB', '#f08', '#201' ) );
 


### PR DESCRIPTION
Simple PR that fixes a typo when creating the memPanel.

`self` is not defined.

Tested on android6.0.1-LgG5-chrome