### PR TITLE
Correctly detect the availability of performance.now()

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -36,9 +36,13 @@ var Stats = function () {
 
 	}
 
+	function now() {
+		return (performance && performance.now) ? performance.now() : Date.now();
+	}
+
 	//
 
-	var beginTime = ( performance || Date ).now(), prevTime = beginTime, frames = 0;
+	var beginTime = now(), prevTime = beginTime, frames = 0;
 
 	var fpsPanel = addPanel( new Stats.Panel( 'FPS', '#0ff', '#002' ) );
 	var msPanel = addPanel( new Stats.Panel( 'MS', '#0f0', '#020' ) );
@@ -62,7 +66,7 @@ var Stats = function () {
 
 		begin: function () {
 
-			beginTime = ( performance || Date ).now();
+			beginTime = now();
 
 		},
 
@@ -70,7 +74,7 @@ var Stats = function () {
 
 			frames ++;
 
-			var time = ( performance || Date ).now();
+			var time = now();
 
 			msPanel.update( time - beginTime, 200 );
 


### PR DESCRIPTION
Closes #87

performance.now() might not exists in some old browsers.
The current code assume that if performance exists, performance.now() exists too.
This might be false, for example on Android stock browser 4.1.2.