### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ This class provides a simple info box that will help you monitor your code perfo
 ![custom.png](https://raw.githubusercontent.com/mrdoob/stats.js/master/files/custom.png)
 
 
+### Installation ###
+
+```bash
+npm i stats-js
+```
+
+
 ### Usage ###
 
 ```javascript


### PR DESCRIPTION
Adding installation instructions via `npm`. Had to go to the `npm` registry to get the name of this project for installation after running `yarn add stats` instead of `yarn add stats-js` and getting the wrong project. Hopefully this change will prevent another need to visit the `npm` registry.