### PR TITLE
Fix bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ requestAnimationFrame( animate );
 You can add this code to any page using the following bookmarklet:
 
 ```javascript
-javascript:(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();document.body.appendChild(stats.dom);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='//mrdoob.github.io/stats.js/build/stats.min.js';document.head.appendChild(script);})()
+javascript:(function(){var script=document.createElement('script');script.onload=function(){var stats=new Stats();document.body.appendChild(stats.dom);requestAnimationFrame(function loop(){stats.update();requestAnimationFrame(loop)});};script.src='https://mrdoob.github.io/stats.js/build/stats.min.js';document.head.appendChild(script);})()
 ```


### PR DESCRIPTION
If you use the bookmarklet as-is, you'll get this CSP error in chrome.

![image](https://user-images.githubusercontent.com/2532112/224094448-83e31096-dfc2-49ff-b90f-cf90dff8b67f.png)
